### PR TITLE
Remove functions config from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,8 @@
   "buildCommand": "npm run vercel-build",
   "outputDirectory": "dist/spa",
   "functions": {
-    "api/**/*.js": {
-      "runtime": "nodejs20.x"
+    "api/index.js": {
+      "runtime": "@vercel/node@3.0.7"
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,6 @@
 {
   "buildCommand": "npm run vercel-build",
   "outputDirectory": "dist/spa",
-  "functions": {
-    "api/index.js": {
-      "runtime": "@vercel/node@3.0.7"
-    }
-  },
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Purpose
Fix Vercel deployment error caused by invalid function runtime configuration. The user was encountering a deployment failure with the error "Function Runtimes must have a valid version, for example `now-php@1.0.0`" when trying to deploy their application to Vercel.

## Code changes
- Removed the `functions` configuration block from `vercel.json`
- Eliminated the `api/**/*.js` runtime specification that was causing the deployment error
- Kept other configuration intact including `buildCommand`, `outputDirectory`, and `rewrites`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/66d3fce58b11400f8411fd78f76b2798/pulse-hub)

👀 [Preview Link](https://66d3fce58b11400f8411fd78f76b2798-pulse-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>66d3fce58b11400f8411fd78f76b2798</projectId>-->
<!--<branchName>pulse-hub</branchName>-->