### PR TITLE
Fix Vercel routing for admin and other pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
     {
       "source": "/api/(.*)",
       "destination": "/api/index.js"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Fix deployment issues on Vercel where the `/admin` route and other pages were returning "not found" errors. The user needed to ensure proper routing configuration for all application routes to work correctly in the Vercel deployment environment.

## Code changes
- Added a catch-all route `"/(.*)"` to `vercel.json` that redirects all unmatched requests to `/index.html`
- This ensures that client-side routing works properly for SPA (Single Page Application) behavior
- The existing API route configuration remains unchanged

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/66d3fce58b11400f8411fd78f76b2798/orbit-world)

👀 [Preview Link](https://66d3fce58b11400f8411fd78f76b2798-orbit-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>66d3fce58b11400f8411fd78f76b2798</projectId>-->
<!--<branchName>orbit-world</branchName>-->